### PR TITLE
Cleanup release binary tarball

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,9 @@ jobs:
       - name: Package
         id: package
         run: |
-          tar czf 'rustberry-jukebox-${{ steps.build-arm-unknown-linux-gnueabihf.outputs.version }}.tar.gz' \
-            jukeboxd/_artifacts/jukeboxd
+          cd jukeboxd/_artifacts
+          tar czvf '../../rustberry-jukebox-${{ steps.build-arm-unknown-linux-gnueabihf.outputs.version }}-${{ matrix.arch }}.tar.gz' \
+            jukeboxd
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -74,8 +75,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./rustberry-jukebox-${{ steps.build-arm-unknown-linux-gnueabihf.outputs.version }}.tar.gz
-          asset_name: rustberry-jukebox-${{ steps.build-arm-unknown-linux-gnueabihf.outputs.version }}.tar.gz
+          asset_path: ./rustberry-jukebox-${{ steps.build-arm-unknown-linux-gnueabihf.outputs.version }}-${{ matrix.arch }}.tar.gz
+          asset_name: rustberry-jukebox-${{ steps.build-arm-unknown-linux-gnueabihf.outputs.version }}-${{ matrix.arch }}.tar.gz
           asset_content_type: application/gzip
       - name: Cache Upload Preparation
         run: |

--- a/jukeboxd/Cargo.lock
+++ b/jukeboxd/Cargo.lock
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "rustberry"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "base64 0.10.1",

--- a/jukeboxd/Cargo.toml
+++ b/jukeboxd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustberry"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Moritz Clasmeier <mtesseract@silverratio.net>"]
 edition = "2018"
 description = "Rustberry Jukebox"


### PR DESCRIPTION
Include architecture in name.
Do not include _artifacts subdirectory in archive.
